### PR TITLE
Add volunteers to activities JSON endpoint

### DIFF
--- a/app/views/activities/_volunteer.json.jbuilder
+++ b/app/views/activities/_volunteer.json.jbuilder
@@ -1,0 +1,5 @@
+json.role volunteer.role
+json.athlete do
+  json.extract! volunteer.athlete, :id, :name, :parkrun_code, :gender
+  json.club volunteer.athlete.club&.name
+end

--- a/app/views/activities/show.json.jbuilder
+++ b/app/views/activities/show.json.jbuilder
@@ -9,3 +9,10 @@ json.results do
     cached: ->(result) { locale_cache_key(result, result.athlete) },
   )
 end
+json.volunteers do
+  json.partial!(
+    'volunteer',
+    collection: @volunteers,
+    as: :volunteer
+  )
+end


### PR DESCRIPTION
Add volunteers to activities JSON endpoint

Currently GET /activities/:id.json returns only run results.
This PR adds a `volunteers` array to the response with role
and athlete info (id, name, parkrun_code, gender, club).