### PR TITLE
Add athlete results and volunteering JSON endpoint

### DIFF
--- a/app/controllers/athletes_controller.rb
+++ b/app/controllers/athletes_controller.rb
@@ -17,10 +17,18 @@ class AthletesController < ApplicationController
 
   def show
     @athlete = Athlete.find params.expect(:id)
-    return redirect_unregistered_athlete if !@athlete.user_id && @athlete.fiveverst_code
+
+    if !@athlete.user_id && @athlete.fiveverst_code
+      return head :not_found if request.format.json?
+
+      return redirect_unregistered_athlete
+    end
 
     load_athlete_results
     load_athlete_volunteering
+
+    return if request.format.json?
+
     @total_events_count = total_events_count
     @total_trophies = @athlete.trophies.size
     @barcode = BarcodeService.call("A#{@athlete.code}", module_size: 8)

--- a/app/views/athletes/show.json.jbuilder
+++ b/app/views/athletes/show.json.jbuilder
@@ -1,0 +1,24 @@
+json.athlete do
+  json.extract! @athlete, :id, :name, :gender, :parkrun_code
+  json.code @athlete.code
+  json.home_event @athlete.event&.name
+  json.club @athlete.club&.name
+end
+
+json.total_results @results.size
+json.total_volunteering @volunteering.size
+
+json.results @results do |result|
+  json.date result.date.iso8601
+  json.total_time result.time_string
+  json.position result.position
+  json.personal_best result.personal_best
+  json.first_run result.first_run
+  json.event result.activity.event, :code_name, :name, :town
+end
+
+json.volunteering @volunteering do |volunteer|
+  json.date volunteer.date.iso8601
+  json.role volunteer.role
+  json.event volunteer.activity.event, :code_name, :name, :town
+end

--- a/spec/requests/athletes_spec.rb
+++ b/spec/requests/athletes_spec.rb
@@ -63,6 +63,62 @@ RSpec.describe '/athletes' do
     end
   end
 
+  describe 'GET /athletes/1.json' do
+    let(:athlete) { create(:athlete, fiveverst_code: nil) }
+    let!(:result) { create(:result, athlete:) }
+    let!(:volunteer) { create(:volunteer, athlete:) }
+
+    let(:expected_body) do
+      {
+        'athlete' => {
+          'id' => athlete.id,
+          'name' => athlete.name,
+          'gender' => 'male',
+          'parkrun_code' => athlete.parkrun_code,
+          'code' => athlete.code,
+          'home_event' => athlete.event&.name,
+          'club' => athlete.club&.name,
+        },
+        'total_results' => 1,
+        'total_volunteering' => 1,
+        'results' => [
+          {
+            'date' => result.date.iso8601,
+            'total_time' => result.time_string,
+            'position' => result.position,
+            'personal_best' => result.personal_best,
+            'first_run' => result.first_run,
+            'event' => result.activity.event.as_json(only: %i[code_name name town]),
+          },
+        ],
+        'volunteering' => [
+          {
+            'date' => volunteer.date.iso8601,
+            'role' => volunteer.role,
+            'event' => volunteer.activity.event.as_json(only: %i[code_name name town]),
+          },
+        ],
+      }
+    end
+
+    it 'renders athlete with results and volunteering in JSON' do
+      get athlete_url(athlete, format: :json)
+
+      expect(response).to be_successful
+      expect(response.parsed_body).to eq(expected_body)
+    end
+
+    context 'when athlete is unregistered and has fiveverst_code' do
+      let(:hidden_athlete) { create(:athlete, parkrun_code: nil) }
+
+      it 'returns not found' do
+        get athlete_url(hidden_athlete, format: :json)
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
   describe 'GET /athletes/:code/best_result' do
     let(:athlete) { create(:athlete) }
 


### PR DESCRIPTION
Adds a JSON view to the existing GET /athletes/:id endpoint so a participant's runs and volunteering can be fetched via API instead of HTML scraping. Hidden (unregistered) profiles return 404, preserving current privacy behaviour. Includes request specs.