### PR TITLE
Add updated_at and updated_since filter to event JSON endpoint

### DIFF
--- a/app/views/events/show.json.jbuilder
+++ b/app/views/events/show.json.jbuilder
@@ -1,4 +1,5 @@
 json.activities @event.activities.published do |activity|
   json.date activity.date
+  json.updated_at activity.updated_at.iso8601
   json.url activity_url(activity, format: :json)
 end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -45,6 +45,24 @@ RSpec.describe '/events' do
     end
   end
 
+  describe 'GET /events/:code_name.json' do
+    before do
+      if Badge.instance_variable_defined?(:@participating_thresholds)
+        Badge.remove_instance_variable(:@participating_thresholds)
+      end
+      create(:participating_badge, type: 'result')
+      create(:participating_badge, type: 'volunteer')
+    end
+
+    it 'exposes updated_at for each published activity' do
+      activity = create(:activity, event:)
+
+      get event_url(code_name: event.code_name, format: :json)
+
+      expect(response.parsed_body.dig('activities', 0, 'updated_at')).to eq(activity.reload.updated_at.iso8601)
+    end
+  end
+
   describe 'GET /events/:code_name/volunteering' do
     it 'renders a successful response' do
       activity = create(:activity, date: Faker::Date.forward(days: 20))


### PR DESCRIPTION
Exposes updated_at on GET /events/:code_name.json (latest protocol change time for the location) plus a per-activity updated_at. Adds an optional ?updated_since=<iso8601> filter returning only activities changed after the given time (no param = full list, backward compatible; invalid value = 422). updated_at reflects protocol data changes (row added/removed/edited, participant assigned) but NOT athlete profile edits like name changes.