### PR TITLE
Add activities changes JSON changefeed endpoint

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -27,6 +27,14 @@ class ActivitiesController < ApplicationController
     @volunteers = @activity.volunteers_roster.includes(athlete: :club)
   end
 
+  def changes
+    scope = Activity.published.where(event: @country_events).includes(:event)
+    scope = scope.where('activities.updated_at > ?', updated_since) if params[:updated_since].present?
+    @activities = scope.order(:updated_at, :id).page(params[:page]).per(100)
+  rescue ArgumentError
+    render json: { error: 'invalid updated_since parameter' }, status: :unprocessable_content
+  end
+
   def dashboard
     @total_results = Result.where(activity_id: weekly_activities_ids)
     @personal_bests_count = @total_results.where(personal_best: true).count
@@ -39,6 +47,10 @@ class ActivitiesController < ApplicationController
   end
 
   private
+
+  def updated_since
+    Time.zone.parse(params[:updated_since]) or raise ArgumentError
+  end
 
   def weekly_activities_ids
     @weekly_activities_ids ||=

--- a/app/views/activities/changes.json.jbuilder
+++ b/app/views/activities/changes.json.jbuilder
@@ -1,0 +1,14 @@
+json.activities @activities do |activity|
+  json.id activity.id
+  json.date activity.date
+  json.updated_at activity.updated_at.iso8601
+  json.url activity_url(activity, format: :json)
+  json.event activity.event, :code_name
+end
+
+json.meta do
+  json.page @activities.current_page
+  json.total_pages @activities.total_pages
+  json.total_count @activities.total_count
+  json.per_page @activities.limit_value
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
   end
   resources :activities, only: %i[index show] do
     get :dashboard, on: :collection
+    get :changes, on: :collection
   end
   scope path: 'athletes' do
     get ':code/best_result', to: 'athletes#best_result', defaults: { format: :json }

--- a/spec/requests/activities_spec.rb
+++ b/spec/requests/activities_spec.rb
@@ -44,4 +44,41 @@ RSpec.describe '/activities' do
       expect(response).to be_successful
     end
   end
+
+  describe 'GET /changes' do
+    it 'returns activities updated after updated_since, ordered by updated_at, with meta' do
+      travel_to(3.days.ago) { create(:activity) }
+      first = travel_to(2.hours.ago) { create(:activity) }
+      second = travel_to(1.hour.ago) { create(:activity) }
+
+      get changes_activities_url(format: :json, updated_since: 1.day.ago.iso8601), headers: { host: 'test.ru' }
+
+      expect(response.parsed_body['activities'].pluck('id')).to eq([first.id, second.id])
+      expect(response.parsed_body['meta']).to include('page' => 1, 'total_pages' => 1, 'total_count' => 2)
+    end
+
+    it 'exposes the event summary and json url per activity' do
+      activity = create(:activity)
+
+      get changes_activities_url(format: :json), headers: { host: 'test.ru' }
+
+      json_activity = response.parsed_body.dig('activities', 0)
+      expect(json_activity['event']).to eq('code_name' => activity.event.code_name)
+      expect(json_activity['url']).to end_with("/activities/#{activity.id}.json")
+    end
+
+    it 'excludes unpublished activities' do
+      create(:activity, published: false)
+
+      get changes_activities_url(format: :json), headers: { host: 'test.ru' }
+
+      expect(response.parsed_body['activities']).to be_empty
+    end
+
+    it 'returns 422 for an invalid updated_since' do
+      get changes_activities_url(format: :json, updated_since: 'not-a-date'), headers: { host: 'test.ru' }
+
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+  end
 end


### PR DESCRIPTION
Adds GET /activities/changes.json — a paginated changefeed of published protocols, ordered by updated_at. Supports ?updated_since=<iso8601> (only activities changed/added after the given time; invalid value returns 422) and ?page=N (100 per page). Each item carries id, date, updated_at, url and event.code_name. Response includes pagination meta (page, total_pages, total_count, per_page). Lets external sync fetch only what changed instead of scraping or re-crawling everything. 