### PR TITLE
Add clubs catalog JSON endpoint

### DIFF
--- a/app/controllers/clubs_controller.rb
+++ b/app/controllers/clubs_controller.rb
@@ -9,6 +9,7 @@ class ClubsController < ApplicationController
     result = @q.result
     result = result.order(:name) if @q.sorts.none? { |s| s.name == 'name' }
     @clubs = result.page(params[:page]).per(25)
+    @clubs = @clubs.includes(logo_attachment: :blob) if request.format.json?
     club_ids = @clubs.map(&:id)
 
     if club_ids.empty?

--- a/app/models/athlete.rb
+++ b/app/models/athlete.rb
@@ -88,6 +88,7 @@ class Athlete < ApplicationRecord
 
   before_save :remove_name_extra_spaces, if: :will_save_change_to_name?
   before_destroy(prepend: true) { results.update_all personal_best: false, first_run: false }
+  before_destroy { Club.where(id: club_id).touch_all if club_id }
   after_save { Club.where(id: saved_change_to_club_id.compact).touch_all if saved_change_to_club_id? }
   after_commit :refresh_home_trophies, if: :saved_change_to_event_id?
 

--- a/app/views/clubs/index.json.jbuilder
+++ b/app/views/clubs/index.json.jbuilder
@@ -1,0 +1,18 @@
+json.clubs @clubs do |club|
+  logo_url = club.logo.attached? ? url_for(club.logo) : nil
+
+  json.slug club.slug
+  json.name club.name
+  json.description club.description
+  json.logo_url logo_url
+  json.updated_at club.updated_at.iso8601
+  json.athletes_count @count_athletes.fetch(club.id, 0)
+  json.results_count @results_stats.dig(club.id, :count) || 0
+end
+
+json.meta do
+  json.page @clubs.current_page
+  json.total_pages @clubs.total_pages
+  json.total_count @clubs.total_count
+  json.per_page @clubs.limit_value
+end

--- a/spec/requests/clubs_spec.rb
+++ b/spec/requests/clubs_spec.rb
@@ -10,6 +10,70 @@ RSpec.describe '/clubs' do
     end
   end
 
+  describe 'GET /.json' do
+    let!(:club) { create(:club, description: 'Test club description') }
+
+    def fetch_club_json
+      get clubs_url(format: :json), headers: { host: 'test.ru' }
+      response.parsed_body['clubs'].find { |c| c['slug'] == club.slug }
+    end
+
+    it 'lists clubs with description, logo, athletes and results counts only' do
+      create(:result, athlete: create(:athlete, club:))
+
+      expect(fetch_club_json).to eq(
+        'slug' => club.slug,
+        'name' => club.name,
+        'description' => club.description,
+        'logo_url' => nil,
+        'updated_at' => club.reload.updated_at.iso8601,
+        'athletes_count' => 1,
+        'results_count' => 1,
+      )
+    end
+
+    it 'includes pagination meta' do
+      fetch_club_json
+
+      expect(response.parsed_body['meta']).to include('page' => 1, 'total_pages' => 1, 'total_count' => 1)
+    end
+
+    it 'bumps updated_at when an athlete joins the club' do
+      before_updated_at = club.updated_at
+
+      travel_to(1.minute.from_now) { create(:athlete, club:) }
+
+      expect(Time.zone.parse(fetch_club_json['updated_at'])).to be > before_updated_at
+    end
+
+    it 'bumps updated_at when an athlete leaves the club' do
+      athlete = create(:athlete, club:)
+      before_updated_at = club.reload.updated_at
+
+      travel_to(1.minute.from_now) { athlete.update!(club: nil) }
+
+      expect(Time.zone.parse(fetch_club_json['updated_at'])).to be > before_updated_at
+    end
+
+    it 'bumps updated_at when a club member is destroyed' do
+      athlete = create(:athlete, club:)
+      before_updated_at = club.reload.updated_at
+
+      travel_to(1.minute.from_now) { athlete.destroy! }
+
+      expect(club.reload.updated_at).to be > before_updated_at
+    end
+
+    it 'does NOT bump updated_at when a new result is added without a club change' do
+      athlete = create(:athlete, club:)
+      before_updated_at = club.reload.updated_at
+
+      travel_to(1.minute.from_now) { create(:result, athlete:) }
+
+      expect(fetch_club_json['updated_at']).to eq(before_updated_at.iso8601)
+    end
+  end
+
   context 'with club' do
     let!(:club) { create(:club) }
 


### PR DESCRIPTION
Adds GET /clubs.json — a paginated catalog of clubs: slug, name, description,
logo URL, athletes_count and results_count. Response includes pagination meta.

Each club has an updated_at field. It bumps when the club roster changes
(an athlete joins, leaves, switches clubs or is deleted) and when club
metadata is edited (name, description, logo). It does not bump from new
results or volunteering of club members.